### PR TITLE
Fix mistranslation

### DIFF
--- a/ui.yaml
+++ b/ui.yaml
@@ -1230,12 +1230,12 @@ label_upload_from_device:
   de: Vom Gerät hochladen
   fr: Télécharger depuis l'appareil
 label_watch:
-  nl: Horloge
+  nl: Volgen
   en: Watch
   de: "Folgen"
   fr: Regardez
 label_watching:
-  nl: "aan het kijken"
+  nl: "aan het volgen"
   en: Watching
   de: "Folgen beenden"
   fr: "En train de regarder"


### PR DESCRIPTION
I've been hunting the source of this mistranslation for many months. To watch a workspace is not "horloge".

Since "Kijken" sounds like something you can open to view it, following is perhaps the better idiom.